### PR TITLE
Optimize eloquent query

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,15 +2,20 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Category;
 use App\Models\Movie;
+use Illuminate\Support\Facades\DB;
 
 class HomeController extends Controller
 {
     public function index()
     {
-        $movies = Movie::all()->sortByDesc(function($movie) {
-            return $movie->ratings->avg('rating');
-        })->take(100);
+        $movies = Movie::with(['ratings', 'category'])
+            ->limit(100)
+            ->get()
+            ->sortByDesc(function ($movie) {
+                return $movie->ratings->avg('rating');
+            });
 
         return view('home', compact('movies'));
     }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,9 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Category;
 use App\Models\Movie;
-use Illuminate\Support\Facades\DB;
 
 class HomeController extends Controller
 {


### PR DESCRIPTION
I expected that doing `Movie::with(['ratings', 'category'])` would make a query like 
`SELECT * FROM movies LEFT JOIN ratings ON ratings.movie_id = movies.id`
`LEFT JOIN categories ON movies.category_id = categories.id;` but it didn't, instead it made 3 separate queries. Other ORMs like [TypeORM](https://typeorm.io/#/) do this with 1 query that uses `LEFT JOIN` which is very effective.

I searched around a bit and I found this [post](https://laravel.io/forum/04-04-2014-why-two-queries-in-relationships-not-join).

Hope you can discuss this in a future video. I enjoyed it a lot.