### PR TITLE
Optimize highest ave rated movies page by delegating all the work to the db [Queries:1 | Models:0 | Mem:4MB]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+APP_HIGHEST_RATED_MOVIES_COUNT=
+
 LOG_CHANNEL=stack
 LOG_LEVEL=debug
 

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,16 +2,47 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Movie;
+use Illuminate\Support\Facades\DB;
 
 class HomeController extends Controller
 {
     public function index()
     {
-        $movies = Movie::all()->sortByDesc(function($movie) {
-            return $movie->ratings->avg('rating');
-        })->take(100);
+        // The query is a little bit large so commenting here for easy reference.
+        //
+        // What we are doing here is taking advantage of sub-query as our main
+        // reference table. Since from the sub-query we already limited the data
+        // to the top 100, all we had to do is join it further and that will
+        // take care of the mapping for the rest of the needed data.
+        //
+        // SELECT movies.title, movies.release_year, categories.name, top100.ave_rating
+        // FROM (
+        //     SELECT AVG(rating) ave_rating, movie_id
+        //     FROM ratings
+        //     GROUP BY movie_id
+        //     ORDER BY ave_rating DESC
+        //     LIMIT 100
+        // ) top100
+        // JOIN movies ON movies.id = top100.movie_id
+        // JOIN categories ON categories.id = movies.category_id;
 
-        return view('home', compact('movies'));
+        $topX = config('app.highest_rated_movies_count');
+
+        $ratingAvgQuery =  DB::table('ratings')
+            ->selectRaw('AVG(rating) ave_rating, movie_id, COUNT(1) votes')
+            ->groupBy('movie_id')
+            ->orderBy('ave_rating', 'desc')
+            ->limit($topX)
+        ;
+
+        $rankedMovies =DB::table(DB::raw("({$ratingAvgQuery->toSql()}) as ranked_ratings"))
+            ->select('movies.title', 'movies.release_year', 'ranked_ratings.ave_rating', 'ranked_ratings.votes', 'categories.name AS category_name')
+            ->join('movies', 'movies.id', '=', 'ranked_ratings.movie_id')
+            ->join('categories', 'categories.id', '=', 'movies.category_id')
+            ->get()
+        ;
+
+        return view('home', compact('rankedMovies', 'topX'));
+
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -2,6 +2,9 @@
 
 return [
 
+    // configure the number of highest ranked movies to show; i.e. Top 10
+    'highest_rated_movies_count' => env('APP_HIGHEST_RATED_MOVIES_COUNT', 100),
+
     /*
     |--------------------------------------------------------------------------
     | Application Name

--- a/database/migrations/2021_08_09_102032_add_movie_id_fk_to_ratings_table.php
+++ b/database/migrations/2021_08_09_102032_add_movie_id_fk_to_ratings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMovieIdFkToRatingsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('ratings', function (Blueprint $table) {
+            $table->foreign('movie_id')->references('id')->on('movies');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('ratings', function (Blueprint $table) {
+            $table->dropForeign(['movie_id']);
+        });
+    }
+}

--- a/database/migrations/2021_08_09_102624_add_category_id_fk_to_movies_table.php
+++ b/database/migrations/2021_08_09_102624_add_category_id_fk_to_movies_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCategoryIdFkToMoviesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('movies', function (Blueprint $table) {
+            $table->foreign('category_id')->references('id')->on('categories');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('movies', function (Blueprint $table) {
+            $table->dropForeign(['category_id']);
+        });
+    }
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -5,7 +5,7 @@
     <div class="row justify-content-center">
         <div class="col-md-12">
             <div class="card">
-                <div class="card-header">{{ __('TOP 100 Movies') }}</div>
+                <div class="card-header">{{ str_replace('100', $topX, __('TOP 100 Movies')) }}</div>
 
                 <div class="card-body">
                     <table class="table table-bordered">
@@ -19,13 +19,13 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach ($movies as $movie)
+                            @foreach ($rankedMovies as $rankedMovie)
                                 <tr>
-                                    <td>{{ $loop->iteration }}. {{ $movie->title }}</td>
-                                    <td>{{ $movie->category->name }}</td>
-                                    <td>{{ $movie->release_year }}</td>
-                                    <td>{{ number_format($movie->ratings->avg('rating'), 2) }}</td>
-                                    <td>{{ $movie->ratings->count() }}</td>
+                                    <td>{{ $loop->iteration }}. {{ $rankedMovie->title }}</td>
+                                    <td>{{ $rankedMovie->category_name }}</td>
+                                    <td>{{ $rankedMovie->release_year }}</td>
+                                    <td>{{ number_format($rankedMovie->ave_rating, 2) }}</td>
+                                    <td>{{ $rankedMovie->votes }}</td>
                                 </tr>
                             @endforeach
                         </tbody>


### PR DESCRIPTION
- add FK to ratings.movie_id and movies.category_id table
- bulk of the change is taking advantage of sub-query as our main reference table. Since from the sub-query we already limited the data to the top 100, all we had to do is join it further and that will take care of the mapping for the rest of the needed data. Sub-query as view is advantageous if the limit is substantially smaller than the total number of data since we are narrowing first our search space before joining. 
- add configurable option for the number of highest rated movies to show.
- result: Queries: 1, Models: 0, Mem: 4MB, Time: 48.62ms (subjective to the machine).

# Screenshots

included some of the data to make sure everything is the same

## Before
<img width="1281" alt="Screen Shot 2021-08-09 at 5 40 52 PM" src="https://user-images.githubusercontent.com/58109867/128694016-25176618-96a6-474c-acd9-dced678b0864.png">

## After

<img width="1280" alt="Screen Shot 2021-08-09 at 5 41 41 PM" src="https://user-images.githubusercontent.com/58109867/128694124-d7601d96-382f-41f6-8327-ae982cb9cf78.png">

<img width="1283" alt="Screen Shot 2021-08-09 at 5 42 01 PM" src="https://user-images.githubusercontent.com/58109867/128694143-15478e0e-2c3b-408b-a402-c85a645c5908.png">



