### PR TITLE
Alternative to other entries. Cached value

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use Carbon\Carbon;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -25,6 +26,9 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         // $schedule->command('inspire')->hourly();
+        $schedule->command(function() {
+            \App\Models\Movie::updateAllRatingsCache(Carbon::now()->subHours(1));
+        })->hourly();
     }
 
     /**

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -8,9 +8,7 @@ class HomeController extends Controller
 {
     public function index()
     {
-        $movies = Movie::all()->sortByDesc(function($movie) {
-            return $movie->ratings->avg('rating');
-        })->take(100);
+        $movies = Movie::topByRating()->take(100)->get();
 
         return view('home', compact('movies'));
     }

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use DateTime;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -24,5 +26,19 @@ class Movie extends Model
     public static function topByRating()
     {
         return self::with('category')->orderByDesc('rating');
+    }
+
+    public function updateRatingsCache()
+    {
+        $this->rating = round($this->ratings->avg('rating'), 2);
+        $this->rating_count = $this->ratings->count();
+    }
+
+    public static function updateAllRatingsCache(DateTimeInterface $since)
+    {
+        foreach(Movie::where('updated_at', '<=', $since)->cursor() as $movie) {
+            $movie->updateRatingsCache();
+            $movie->save();
+        }
     }
 }

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -20,4 +20,9 @@ class Movie extends Model
     {
         return $this->belongsTo(Category::class);
     }
+
+    public static function topByRating()
+    {
+        return self::with('category')->orderByDesc('rating');
+    }
 }

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -36,7 +36,7 @@ class Movie extends Model
 
     public static function updateAllRatingsCache(DateTimeInterface $since)
     {
-        foreach(Movie::where('updated_at', '<=', $since)->cursor() as $movie) {
+        foreach(Movie::where('updated_at', '<=', $since)->lazy() as $movie) {
             $movie->updateRatingsCache();
             $movie->save();
         }

--- a/database/migrations/2021_08_09_211715_add_ratings_to_movie_model.php
+++ b/database/migrations/2021_08_09_211715_add_ratings_to_movie_model.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Movie;
+
+class AddRatingsToMovieModel extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('movies', function (Blueprint $table) {
+            $table->decimal('rating', 4, 2, true)->nullable(false)->default(0)->index();
+            $table->integer('rating_count', false, true)->nullable(false)->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('movies', function (Blueprint $table) {
+            $table->dropColumn(['rating', 'rating_count']);
+        });
+    }
+}

--- a/database/migrations/2021_08_23_073215_initial_populate_movie_rating_and_rating_count.php
+++ b/database/migrations/2021_08_23_073215_initial_populate_movie_rating_and_rating_count.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Movie;
+
+class InitialPopulateMovieRatingAndRatingCount extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        foreach(Movie::cursor() as $movie) {
+            $movie->rating = round($movie->ratings->avg('rating'), 2);
+            $movie->rating_count = $movie->ratings->count();
+            $movie->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        foreach(Movie::cursor() as $movie) {
+            $movie->rating = 0;
+            $movie->rating_count = 0;
+            $movie->save();
+        }
+    }
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -24,8 +24,8 @@
                                     <td>{{ $loop->iteration }}. {{ $movie->title }}</td>
                                     <td>{{ $movie->category->name }}</td>
                                     <td>{{ $movie->release_year }}</td>
-                                    <td>{{ number_format($movie->ratings->avg('rating'), 2) }}</td>
-                                    <td>{{ $movie->ratings->count() }}</td>
+                                    <td>{{ number_format($movie->rating, 2) }}</td>
+                                    <td>{{ $movie->rating_count }}</td>
                                 </tr>
                             @endforeach
                         </tbody>


### PR DESCRIPTION
This is naughty, but also simple to reason about:

* We simply add the fields we want to our table, using Laravel (could also use DBMS specific features).
* Retrieve the cached (non-live) value.
* In migration we seed the table with values.
* In Scheduled task we keep the ratings data fresh, ignoring recently updated entries.

This would better suit a queue-task based system with a lot of rows.

I Just wanted to present something that wasn't playing with the query builder or abandoning eloquent, but was also simple for most levels to get their head around.

### References

* https://laravel.com/docs/8.x/scheduling
* https://laravel.com/docs/8.x/migrations#migration-structure
* https://laravel.com/docs/8.x/eloquent#chunking-results

So we are paying the cost of the original queries, but only when needed, which opens to door to other optimisations.

No matter how much you optimise the queries, you'll be performing them 1 time every page visit.

Another thing you could do is add cache, which is simpler, although that seems to avoid the eloquent requirement, which is why I avoided.

~`cursor` could become `lazy` I think for some small win in some situations (we only ever fetch top 100 results here).~

~423 lines of this are composer noise so I could rollback to `main` and continue seeding until I iterated past editing the migration. The PHP is 67 net lines.~